### PR TITLE
Clone original background declaration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,7 @@ function at2x({ identifier = '@2x' } = {}) {
         // Construct a duplicate rule but with the image urls
         // replaced with retina versions
         const retinaRule = postcss.rule({ selector: decl.parent.selector });
-        retinaRule.append(postcss.decl({
-          prop: decl.prop,
+        retinaRule.append(decl.clone({
           value: createRetinaUrl(decl.value, identifier)
         }));
 


### PR DESCRIPTION
From [PostCSS API docs](http://api.postcss.org/Declaration.html#source):

> If you create a node manually (e.g., with postcss.decl()), that node will not have a source property and will be absent from the source map. For this reason, the plugin developer should consider cloning nodes to create new ones (in which case the new node’s source will reference the original, cloned node) or setting the source property manually.

If there is no original source input file information, plugins like [postcss-copy](https://github.com/geut/postcss-copy) can’t copy file to new location and update declarations.