### PR TITLE
Move Babel to development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "main": "build/index.js",
   "dependencies": {
-    "babel-cli": "^6.24.1",
     "image-size": "^0.6.0",
     "is-url": "^1.2.2",
     "pify": "^3.0.0",
@@ -25,6 +24,7 @@
     "string.prototype.includes": "^1.0.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-rewire": "^1.1.0",
     "babel-preset-env": "^1.6.0",


### PR DESCRIPTION
Babel CLI is installed as project dependancy even though it’s used only in development when building package.